### PR TITLE
Docs/create all categories and sub categories as links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This is a simple Hangman Game were you guess what letters come into the spaces.
 
 ## [Planning](#table-of-content)
 
-### [Colour Pallet](#colour-pallet)
+### [Colour Pallet](#table-of-content)
 
 ![color-pallet.png](assets/images/readme/planning/color-pallet.png)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This is a simple Hangman Game were you guess what letters come into the spaces.
     - [GitHub: Pros and Cons](#github--pros-and-cons)
     - [Jetbrains Spaces: Pros and Cons](#jetbrains-spaces--pros-and-cons)
   - [Wire framing](#wire-framing)
+    - [Mobile Devices](#mobile-device)
+    - [Tablet Devices](#table-of-content)
 - [Bugs and Planning](#bugs-and-problems)
   - [Array appending instead of replacing](#array-appending-instead-of-replacing)
   - [Hangman Images not Changing on tries variable change](#hangman-images-not-changing-on-tries-variable-change)
@@ -65,7 +67,7 @@ their products are good and I enjoy using them.
 
 ![wireframe-mobile.png](assets/images/readme/planning/wireframe-mobile.png)
 
-Tablet Device
+#### [Tablet Device](#table-of-content)
 
 ![wireframe-tablet.png](assets/images/readme/planning/wireframe-tablet.png)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ This is a simple Hangman Game were you guess what letters come into the spaces.
     - [Jetbrains Spaces: Pros and Cons](#jetbrains-spaces--pros-and-cons)
   - [Wire framing](#wire-framing)
     - [Mobile Devices](#mobile-device)
-    - [Tablet Devices](#table-of-content)
+    - [Tablet Devices](#tablet-device)
+    - [Desktop Devices](#desktop-devices)
 - [Bugs and Planning](#bugs-and-problems)
   - [Array appending instead of replacing](#array-appending-instead-of-replacing)
   - [Hangman Images not Changing on tries variable change](#hangman-images-not-changing-on-tries-variable-change)
@@ -71,7 +72,7 @@ their products are good and I enjoy using them.
 
 ![wireframe-tablet.png](assets/images/readme/planning/wireframe-tablet.png)
 
-Desktop Devices
+#### [Desktop Devices](#table-of-content)
 
 ![wireframe-desktop.png](assets/images/readme/planning/wireframe-desktop.png)
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is a simple Hangman Game were you guess what letters come into the spaces.
 - [Planning](#planning)
   - [Colour Pallet](#colour-pallet)
   - [Technology Used](#technology-used)
+    - [GitHub: Pros and Cons](#github--pros-and-cons)
   - [Wire framing](#wire-framing)
 - [Bugs and Planning](#bugs-and-problems)
   - [Array appending instead of replacing](#array-appending-instead-of-replacing)
@@ -39,7 +40,7 @@ Comparison of using GitHub and Jetbrains Spaces.
 The reason that I decided to use the two version control systems was I wanted to explore more of their products, as
 their products are good and I enjoy using them.
 
-#### GitHub
+#### [GitHub: Pros and Cons](#table-of-content)
 
 | Pros                                      | Cons                               |
 |-------------------------------------------|------------------------------------|

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Introduction
+## [Introduction](#table-of-content)
 
 This is the second Milestone Project with Code Institute.
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This is a simple Hangman Game were you guess what letters come into the spaces.
 - [Planning](#planning)
   - [Colour Pallet](#colour-pallet)
   - [Technology Used](#technology-used)
-    - [GitHub: Pros and Cons](#github--pros-and-cons)
-    - [Jetbrains Spaces: Pros and Cons](#jetbrains-spaces--pros-and-cons)
+    - [GitHub: Pros and Cons](#github-pros-and-cons)
+    - [Jetbrains Spaces: Pros and Cons](#jetbrains-spaces-pros-and-cons)
   - [Wire framing](#wire-framing)
     - [Mobile Devices](#mobile-device)
     - [Tablet Devices](#tablet-device)
@@ -44,7 +44,7 @@ Comparison of using GitHub and Jetbrains Spaces.
 The reason that I decided to use the two version control systems was I wanted to explore more of their products, as
 their products are good and I enjoy using them.
 
-#### [GitHub: Pros and Cons](#table-of-content)
+#### [GitHub Pros and Cons](#table-of-content)
 
 | Pros                                      | Cons                               |
 |-------------------------------------------|------------------------------------|
@@ -52,7 +52,7 @@ their products are good and I enjoy using them.
 | Easy to create a new repository           | difficult to organise repositories |
 | Can create private or public repositories |                                    |
 
-#### [Jetbrains Spaces: Pros and Cons](#table-of-content)
+#### [Jetbrains Spaces Pros and Cons](#table-of-content)
 
 | Pros                                                   | Cons                                          |
 |--------------------------------------------------------|-----------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ their products are good and I enjoy using them.
 | Integrates well with Jetbrains products                | Can only create private repositories          |
 | Easy to organise repositories into projects            |                                               |
 
-### Wire framing
+### [Wire framing](#table-of-content)
 
 Mobile Device
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ This is a simple Hangman Game were you guess what letters come into the spaces.
 
 ## [Planning](#table-of-content)
 
-### Colour Pallet
+### [Colour Pallet](#colour-pallet)
 
 ![color-pallet.png](assets/images/readme/planning/color-pallet.png)
 
 [URL: color space](https://mycolor.space/?hex=%2333976F&sub=1)
 
-### Technology Used
+### [Technology Used](#table-of-content)
 
 - figma—designing the wire frame diagram
 - GitHub and Jetbrains Spaces—version control system

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ their products are good and I enjoy using them.
 
 ### [Wire framing](#table-of-content)
 
-Mobile Device
+#### [Mobile Device](#table-of-content)
 
 ![wireframe-mobile.png](assets/images/readme/planning/wireframe-mobile.png)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is a simple Hangman Game were you guess what letters come into the spaces.
   - [Colour Pallet](#colour-pallet)
   - [Technology Used](#technology-used)
     - [GitHub: Pros and Cons](#github--pros-and-cons)
+    - [Jetbrains Spaces: Pros and Cons](#jetbrains-spaces--pros-and-cons)
   - [Wire framing](#wire-framing)
 - [Bugs and Planning](#bugs-and-problems)
   - [Array appending instead of replacing](#array-appending-instead-of-replacing)
@@ -48,7 +49,7 @@ their products are good and I enjoy using them.
 | Easy to create a new repository           | difficult to organise repositories |
 | Can create private or public repositories |                                    |
 
-#### Jetbrains Spaces
+#### [Jetbrains Spaces: Pros and Cons](#table-of-content)
 
 | Pros                                                   | Cons                                          |
 |--------------------------------------------------------|-----------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a simple Hangman Game were you guess what letters come into the spaces.
 
 ---
 
-## Planning
+## [Planning](#table-of-content)
 
 ### Colour Pallet
 


### PR DESCRIPTION
- created the introduction section as a link to table of content
- created planning as a link to a table of content
- created technology used as a link to a table of content
- created a link for GitHub pros and cons
- created a links for jetbrains spaces: pros and cons
- created a link for wire framing to table-of-content
- changed mobile devices to a heading and a link
- changed tablet devices to a heading and created it as a link
- deleted extra "-" in link for GitHub and spaces
- rectified link for color pallet