### PR TITLE
Feat/discard reset button

### DIFF
--- a/assets/css/media.css
+++ b/assets/css/media.css
@@ -137,11 +137,6 @@
   .overlay-text {
     font-size: 5rem;
   }
-  .overlay-button {
-    width: 15rem;
-    height: 8rem;
-    font-size: 3rem;
-  }
 
   /*sound toggle*/
   .sound {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -67,17 +67,6 @@ h1 {
 .overlay-text p {
   margin: 5rem;
 }
-.overlay-button {
-  color: #33976f;
-  font-weight: bold;
-  background-color: #00ffff;
-  border: 2px solid red;
-  border-radius: 5px;
-  width: 5rem;
-  height: 2rem;
-  margin: 2rem;
-  justify-content: center;
-}
 
 /*sound toggle*/
 .sound {

--- a/assets/js/utils/overlay/how-to-play.js
+++ b/assets/js/utils/overlay/how-to-play.js
@@ -21,6 +21,8 @@ export const howToPlay = () => {
                 <li>points: add 2 points per correct and subtract 1 point per incorrect answers</li>
                 <li>You get a total of 10 tries to guess the word</li>
                 <li>The Game is won by getting 20 points, and lost when tries hit 0</li>
+                <li>When the win/loss is displayed, click anywhere on the screen will reset the game board</li>
+                <li>Clicking anywhere on this screen will resume the game</li>
            </ul>
            `;
 

--- a/assets/js/utils/overlay/how-to-play.js
+++ b/assets/js/utils/overlay/how-to-play.js
@@ -21,9 +21,6 @@ export const howToPlay = () => {
                 <li>points: add 2 points per correct and subtract 1 point per incorrect answers</li>
                 <li>You get a total of 10 tries to guess the word</li>
                 <li>The Game is won by getting 20 points, and lost when tries hit 0</li>
-                <button class="overlay-button" onclick="function overlayBtn() {
-                    id.style.display = 'none'
-                }">Close</button>
            </ul>
            `;
 

--- a/assets/js/utils/overlay/loss.js
+++ b/assets/js/utils/overlay/loss.js
@@ -14,7 +14,6 @@ export const loss = () => {
         <hr>
         <p>The correct word is: ${hidden}</p>
         <p>Would you like to play again?</p>
-        <button class="overlay-button" onclick="window.location.reload()">Reset</button>
     `;
 
   flag.innerHTML = "False";

--- a/assets/js/utils/overlay/win.js
+++ b/assets/js/utils/overlay/win.js
@@ -12,7 +12,6 @@ export const win = () => {
         <h2>Congratulation</h2>
         <hr>
         <p>Would you like to play again?</p>
-        <button class="overlay-button" onclick="window.location.reload()">Reset</button>
     `;
 
   flag.innerHTML = "False";


### PR DESCRIPTION
- Reset button has been deleted from loss/win and how-to-play overlay

![image](https://github.com/douglas86/hangman/assets/31186100/e05655e2-ce82-4931-bbca-d91e6254aa09)
